### PR TITLE
App: fix Gradle to work with AGP 9.0

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -22,11 +22,11 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: set up JDK 17
+      - name: set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '17'
+          java-version: '21'
           cache: gradle
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/renovate_check.yml
+++ b/.github/workflows/renovate_check.yml
@@ -20,11 +20,11 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: set up JDK 17
+      - name: set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '17'
+          java-version: '21'
           cache: gradle
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/tag_create_release.yml
+++ b/.github/workflows/tag_create_release.yml
@@ -19,11 +19,11 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: set up JDK 17
+      - name: set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '17'
+          java-version: '21'
           cache: gradle
 
       - name: Grant execute permission for gradlew

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ link, etc., indeed this is how Reddit implements this feature in their Android A
 
 ### Let's download and run it!
 
-This project was configured to build using Android Studio Narwhal Feature Drop | 2025.1.2 RC 1. You will need to have
-Java 17 to build the project.
+This project was configured to build using Android Studio Otter 3 Feature Drop | 2025.2.3. You will need to have
+Java 21 to build the project.
 
 Alternatively, you can find the ready-to-install APKs and App Bundles under
 the [release section](https://github.com/ryanw-mobile/XLauncherIcons/releases).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.ManagedVirtualDevice
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import java.io.FileInputStream
@@ -8,7 +9,6 @@ import java.util.Properties
 
 plugins {
     alias(libs.plugins.androidApplication)
-    alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.detekt)
     alias(libs.plugins.kotlinter)
@@ -59,13 +59,13 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {
@@ -97,8 +97,8 @@ tasks {
 
 detekt { parallel = true }
 
-// Gradle Build Utilities
-private fun BaseAppModuleExtension.setupSdkVersionsFromVersionCatalog() {
+// Gradle Build Utilities - Revision 2026.01.22.01
+private fun ApplicationExtension.setupSdkVersionsFromVersionCatalog() {
     compileSdk = libs.versions.compileSdk.get().toInt()
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
@@ -108,7 +108,7 @@ private fun BaseAppModuleExtension.setupSdkVersionsFromVersionCatalog() {
     }
 }
 
-private fun BaseAppModuleExtension.setupPackagingResourcesDeduplication() {
+private fun ApplicationExtension.setupPackagingResourcesDeduplication() {
     packaging.resources {
         excludes.addAll(
             listOf(
@@ -130,25 +130,31 @@ private fun BaseAppModuleExtension.setupPackagingResourcesDeduplication() {
     }
 }
 
-private fun BaseAppModuleExtension.setupSigningAndBuildTypes() {
+private fun ApplicationExtension.setupSigningAndBuildTypes() {
+    val isReleaseSigningEnabled =
+        providers.gradleProperty("releaseSigning")
+            .map { it.toBoolean() }
+            .orElse(false)
+            .get()
+
     val releaseSigningConfigName = "releaseSigningConfig"
     val timestamp = SimpleDateFormat("yyyyMMdd-HHmmss").format(Date())
     val baseName = "$productApkName-${libs.versions.versionName.get()}-$timestamp"
     val isReleaseBuild = gradle.startParameter.taskNames.any {
-        it.contains("Release", ignoreCase = true)
-                || it.contains("Bundle", ignoreCase = true)
-                || it.equals("build", ignoreCase = true)
+        it.contains("Release", ignoreCase = true) ||
+                it.contains("Bundle", ignoreCase = true)
     }
 
-    extensions.configure<BasePluginExtension> { archivesName.set(baseName) }
+    project.extensions.configure<BasePluginExtension> { archivesName.set(baseName) }
 
     signingConfigs.create(releaseSigningConfigName) {
         // Only initialise the signing config when a Release or Bundle task is being executed.
         // This prevents Gradle sync or debug builds from attempting to load the keystore,
         // which could fail if the keystore or environment variables are not available.
         // SigningConfig itself is only wired to the 'release' build type, so this guard avoids unnecessary setup.
-        if (isReleaseBuild) {
+        if (isReleaseBuild && isReleaseSigningEnabled) {
             val keystorePropertiesFile = file("../../keystore.properties")
+            println("🔑 Searching for keystore at ${keystorePropertiesFile.absolutePath}: exist? ${keystorePropertiesFile.exists()}")
 
             if (isRunningOnCI || !keystorePropertiesFile.exists()) {
                 println("⚠\uFE0F Signing Config: using environment variables")
@@ -172,27 +178,15 @@ private fun BaseAppModuleExtension.setupSigningAndBuildTypes() {
                 storePassword = properties.getProperty("storePass")
             }
         } else {
-            println("⚠\uFE0F Signing Config: not created for non-release builds.")
+            println("⚠️ Signing Config: skipped (no release signing intent)")
         }
     }
 
     buildTypes {
-        fun setOutputFileName() {
-            applicationVariants.all {
-                outputs
-                    .map { it as com.android.build.gradle.internal.api.BaseVariantOutputImpl }
-                    .forEach { output ->
-                        val outputFileName = "$productApkName-$name-$versionName-$timestamp.apk"
-                        output.outputFileName = outputFileName
-                    }
-            }
-        }
-
         getByName("debug") {
             applicationIdSuffix = ".debug"
             isMinifyEnabled = false
             isDebuggable = true
-            setOutputFileName()
         }
 
         getByName("release") {
@@ -205,8 +199,9 @@ private fun BaseAppModuleExtension.setupSigningAndBuildTypes() {
                     "proguard-rules.pro",
                 ),
             )
-            signingConfig = signingConfigs.getByName(name = releaseSigningConfigName)
-            setOutputFileName()
+            if (isReleaseSigningEnabled) {
+                signingConfig = signingConfigs.getByName(name = releaseSigningConfigName)
+            }
         }
     }
 }

--- a/app/src/androidTest/java/com/rwmobi/xlaunchericons/ui/test/SemanticsMatchers.kt
+++ b/app/src/androidTest/java/com/rwmobi/xlaunchericons/ui/test/SemanticsMatchers.kt
@@ -3,7 +3,7 @@
  * https://github.com/ryanw-mobile
  */
 
-package com.rwmobi.giphytrending.ui.test
+package com.rwmobi.xlaunchericons.ui.test
 
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsProperties

--- a/app/src/main/java/com/rwmobi/xlaunchericons/ui/theme/Theme.kt
+++ b/app/src/main/java/com/rwmobi/xlaunchericons/ui/theme/Theme.kt
@@ -53,6 +53,7 @@ fun XLauncherIconsTheme(
             }
 
             darkTheme -> DarkColorScheme
+
             else -> LightColorScheme
         }
     val view = LocalView.current

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.androidApplication) apply false
-    alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.kotlinter) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.nonFinalResIds=false
+android.nonFinalResIds=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.2"
+agp = "9.0.0"
 kotlin = "2.3.0"
 core-ktx = "1.17.0"
 junit = "4.13.2"
@@ -38,7 +38,6 @@ androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
-kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }


### PR DESCRIPTION
# Pull Request: Upgrade to AGP 9.0 and JDK 21

## Description
This PR upgrades the project's build infrastructure to support **Android Gradle Plugin (AGP) 9.0.0** and migrates the toolchain to **JDK 21**. It also includes build script refactoring for better compatibility with modern AGP APIs and minor test code corrections.

### Key Changes

#### 🛠 Build & Toolchain
*   **AGP Upgrade:** Updated `agp` version to `9.0.0` in `libs.versions.toml`.
*   **JDK 21 Migration:**
    *   Updated GitHub Actions workflows (`main_build`, `renovate_check`, `tag_create_release`) to use JDK 21.
    *   Updated `jvmToolchain` and `compileOptions` in `app/build.gradle.kts` to Java 21.
*   **Gradle Settings:** Set `android.nonFinalResIds=true` in `gradle.properties` as required/recommended by newer AGP versions.

#### 📝 Build Script Refactoring (`app/build.gradle.kts`)
*   **API Migration:** Switched from `BaseAppModuleExtension` to `ApplicationExtension` for Gradle utility functions.
*   **Signing Logic:** Introduced a `releaseSigning` Gradle property check to prevent unnecessary keystore lookups during debug builds or environment-restricted runs.
*   **Cleanups:**
    *   Removed the redundant `kotlinAndroid` plugin (now handled via `androidApplication`).
    *   Streamlined `archivesName` configuration using `project.extensions`.
    *   Removed manual APK renaming logic in favor of standard AGP outputs.

#### 🐛 Fixes & Docs
*   **Package Fix:** Corrected an incorrect package name in `SemanticsMatchers.kt` that was left over from a previous project template.
*   **README:** Updated "How to build" instructions to specify Android Studio Otter 3 and Java 21.

## How Has This Been Tested?
*   [x] Project syncs successfully with AGP 9.0.
*   [x] Debug build compiles and runs.
*   [x] Unit and Instrumented tests verified (fixing the package name mismatch).