### PR TITLE
[chore] Renovate: serial queue, pinDigests + ecosystem groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,11 @@
   "extends": [
     "config:recommended"
   ],
+  "pinDigests": true,
   "commitMessagePrefix": "[chore] Renovate: ",
   "commitMessageExtra": "{{{currentValue}}} to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
   "assignAutomerge": false,
+  "prConcurrentLimit": 1,
   "reviewers": [
     "ryanw-mobile"
   ],
@@ -29,6 +31,13 @@
       "groupName": "kotlin",
       "matchPackageNames": [
         "/com.google.devtools.ksp/"
+      ]
+    },
+    {
+      "groupName": "material3",
+      "matchPackageNames": [
+        "androidx.compose.material3:material3",
+        "androidx.compose.material3:material3-adaptive-navigation-suite"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

- **`pinDigests: true`** — pins GitHub Actions to commit SHAs.
- **`prConcurrentLimit: 1`** — one Renovate PR open at a time, eliminating the rebase cascade (N simultaneous PRs → up to N(N+1)/2 CI runs).
- **`material3` group** *(where applicable)* — bundles `material3` + `material3-adaptive-navigation-suite`, which always release together.
- **`firebase` group** *(where applicable)* — bundles `firebase-bom` + `firebase-crashlytics` plugin, consistently 0–1 days apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)